### PR TITLE
Implemented protobuf extends

### DIFF
--- a/test/fixtures/basic.json
+++ b/test/fixtures/basic.json
@@ -2,11 +2,13 @@
   "package": null,
   "imports": [],
   "enums": [],
+  "extends": [],
   "messages": [
     {
       "name": "Point",
       "enums": [],
       "messages": [],
+      "extensions": null,
       "fields": [
         {
           "name": "x",
@@ -37,6 +39,7 @@
     {
       "name": "Line",
       "enums": [],
+      "extensions": null,
       "messages": [],
       "fields": [
         {

--- a/test/fixtures/comments.json
+++ b/test/fixtures/comments.json
@@ -2,11 +2,13 @@
   "package": null,
   "imports": [],
   "enums": [],
+  "extends": [],
   "messages": [
     {
       "name": "Point",
       "enums": [],
       "messages": [],
+      "extensions": null,
       "fields": [
         {
           "name": "x",
@@ -37,6 +39,7 @@
     {
       "name": "Line",
       "enums": [],
+      "extensions": null,
       "messages": [],
       "fields": [
         {

--- a/test/fixtures/complex.json
+++ b/test/fixtures/complex.json
@@ -2,9 +2,11 @@
   "package": "tutorial",
   "imports": [],
   "enums": [],
+  "extends": [],
   "messages": [
     {
       "name": "Person",
+      "extensions": null,
       "enums": [
         {
           "name": "PhoneType",
@@ -20,6 +22,7 @@
           "name": "PhoneNumber",
           "enums": [],
           "messages": [],
+          "extensions": null,
           "fields": [
             {
               "name": "number",
@@ -81,6 +84,7 @@
       "name": "AddressBook",
       "enums": [],
       "messages": [],
+      "extensions": null,
       "fields": [
         {
           "name": "person",

--- a/test/fixtures/extend.json
+++ b/test/fixtures/extend.json
@@ -1,0 +1,136 @@
+{
+  "package": null,
+  "imports": [],
+  "enums": [],
+  "messages": [
+    {
+      "name": "MsgNormal",
+      "enums": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "field1",
+          "type": "int32",
+          "tag": 1,
+          "required": true,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "field2",
+          "type": "string",
+          "tag": 2,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "field3",
+          "type": "int32",
+          "tag": 3,
+          "required": true,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "exField1",
+          "type": "int32",
+          "tag": 101,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "exField2",
+          "type": "string",
+          "tag": 102,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        }
+      ],
+      "extensions": null
+    },
+    {
+      "name": "MsgExtend",
+      "enums": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "field1",
+          "type": "int32",
+          "tag": 1,
+          "required": true,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "field2",
+          "type": "string",
+          "tag": 2,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "field3",
+          "type": "int32",
+          "tag": 3,
+          "required": true,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "exField1",
+          "type": "int32",
+          "tag": 101,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "exField2",
+          "type": "string",
+          "tag": 102,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        }
+      ],
+      "extensions": {
+        "from": 100,
+        "to": 200
+      }
+    }
+  ],
+  "options": {},
+  "extends": [
+    {
+      "name": "MsgExtend",
+      "message": {
+        "name": "MsgExtend",
+        "enums": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "exField1",
+            "type": "int32",
+            "tag": 101,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          },
+          {
+            "name": "exField2",
+            "type": "string",
+            "tag": 102,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    }
+  ]
+}

--- a/test/fixtures/extend.proto
+++ b/test/fixtures/extend.proto
@@ -1,0 +1,19 @@
+message MsgNormal {
+	required int32 field1 = 1;
+	optional string field2 = 2;
+	required int32 field3 = 3;
+	optional int32 exField1 = 101;
+	optional string exField2 = 102;
+}
+
+message MsgExtend {
+	required int32 field1 = 1;
+	optional string field2 = 2;
+	required int32 field3 = 3;
+	extensions 100 to 200;
+}
+
+extend MsgExtend {
+	optional int32 exField1 = 101;
+	optional string exField2 = 102;
+}

--- a/test/fixtures/search.json
+++ b/test/fixtures/search.json
@@ -2,8 +2,10 @@
 	"package":null,
 	"imports": ["./result.proto"],
 	"enums":[],
+	"extends": [],
 	"messages":[{
 		"name":"SearchResponse",
+		"extensions": null,
 		"enums":[],
 		"messages":[],
 		"fields":[

--- a/test/index.js
+++ b/test/index.js
@@ -55,3 +55,15 @@ tape('schema with imports loaded by path', function(t) {
   t.same(schema.parse(fixture('search.proto')), require('./fixtures/search.json'))
   t.end()
 })
+
+tape('schema with extends', function(t) {
+  t.same(schema.parse(fixture('extend.proto')), require('./fixtures/extend.json'))
+  t.end()
+})
+
+
+tape('comparing extended and not extended schema', function(t) {
+  var sch = schema.parse(fixture('extend.proto'))
+  t.same(sch.messages.MsgNormal, sch.messages.MsgExtend)
+  t.end()
+})


### PR DESCRIPTION
This is one of 2 pull requests across protocol-buffer and resolve-protobuf-schema repositories that fixes imports of external protobuf files. now you can specify root_dir that defines base place from where all files are looked-up (as defined in protobuf specification: https://developers.google.com/protocol-buffers/docs/proto#other. 
You need to test it together with https://github.com/mafintosh/protocol-buffers/pull/13.
