### PR TITLE
add "support" for option in enum

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -213,6 +213,11 @@ var onenum = function(tokens) {
       if (tokens[0] === ';') tokens.shift()
       return e
     }
+    if (tokens[0] === 'option') {
+      // just skip "option allow_alias = true;"
+      while (tokens.shift() !== ';') {
+      }
+    }
     var val = onenumvalue(tokens)
     e.values[val.name] = val.value
   }


### PR DESCRIPTION
protobug-schema implicitly allows aliases of same value in enum, but according to spec, this should be implicitly declared with "option allow_alias = true;"
This pull request simply skips this declaration so that the .proto won't crash.
