### PR TITLE
Syntax version parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm install protocol-buffers-schema
 First save the following file as `example.proto`
 
 ```proto
+syntax = "proto2";
+
 message Point {
   required int32 x = 1;
   required int32 y=2;
@@ -43,6 +45,7 @@ Running the above example will print something like
 
 ``` js
 {
+  syntax: 2,
   package: null,
   enums: [],
   messages: [{

--- a/stringify.js
+++ b/stringify.js
@@ -81,6 +81,9 @@ var indent = function (lvl) {
 
 module.exports = function (schema) {
   var result = []
+
+  result.push('syntax = "proto' + schema.syntax + '";', '')
+
   if (schema.package) result.push('package ' + schema.package + ';', '')
 
   if (!schema.options) schema.options = {}

--- a/test/fixtures/comments.json
+++ b/test/fixtures/comments.json
@@ -1,4 +1,5 @@
 {
+  "syntax": 3,
   "package": null,
   "imports": [],
   "enums": [],

--- a/test/fixtures/complex.json
+++ b/test/fixtures/complex.json
@@ -1,4 +1,5 @@
 {
+  "syntax": 3,
   "package": "tutorial",
   "imports": [],
   "enums": [],

--- a/test/fixtures/extend.json
+++ b/test/fixtures/extend.json
@@ -1,4 +1,5 @@
 {
+  "syntax": 3,
   "package": null,
   "imports": [],
   "enums": [],

--- a/test/fixtures/map.json
+++ b/test/fixtures/map.json
@@ -1,4 +1,5 @@
 {
+  "syntax": 3,
   "package": null,
   "imports": [],
   "enums": [],

--- a/test/fixtures/oneof.json
+++ b/test/fixtures/oneof.json
@@ -1,4 +1,5 @@
 {
+  "syntax": 3,
   "package": null,
   "imports": [],
   "enums": [],

--- a/test/fixtures/search.json
+++ b/test/fixtures/search.json
@@ -1,4 +1,5 @@
 {
+	"syntax": 3,
 	"package": null,
 	"imports": ["./result.proto"],
 	"enums": [],

--- a/test/fixtures/version.json
+++ b/test/fixtures/version.json
@@ -1,5 +1,5 @@
 {
-  "syntax": 3,
+  "syntax": 2,
   "package": null,
   "imports": [],
   "enums": [],

--- a/test/fixtures/version.proto
+++ b/test/fixtures/version.proto
@@ -1,0 +1,13 @@
+syntax = "proto2";
+
+message Point {
+  required int32 x = 1;
+  required int32 y = 2;
+  optional string label = 3;
+}
+
+message Line {
+  required Point start = 1;
+  required Point end = 2;
+  optional string label = 3;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,8 @@ tape('basic parse', function (t) {
 })
 
 tape('basic parse + stringify', function (t) {
-  t.same(schema.stringify(schema.parse(fixture('basic.proto'))), fixture('basic.proto'))
+  var syntax = 'syntax = "proto3";\n\n'
+  t.same(schema.stringify(schema.parse(fixture('basic.proto'))), syntax + fixture('basic.proto'))
   t.end()
 })
 
@@ -23,7 +24,8 @@ tape('complex parse', function (t) {
 })
 
 tape('complex parse + stringify', function (t) {
-  t.same(schema.stringify(schema.parse(fixture('complex.proto'))), fixture('complex.proto'))
+  var syntax = 'syntax = "proto3";\n\n'
+  t.same(schema.stringify(schema.parse(fixture('complex.proto'))), syntax + fixture('complex.proto'))
   t.end()
 })
 
@@ -75,4 +77,18 @@ tape('schema with oneof', function (t) {
 tape('schema with map', function (t) {
   t.same(schema.parse(fixture('map.proto')), require('./fixtures/map.json'))
   t.end()
+})
+
+tape('schema with syntax version', function (t) {
+  t.same(schema.parse(fixture('version.proto')), require('./fixtures/version.json'))
+  t.end()
+})
+
+tape('throws on misplaced syntax version', function (t) {
+  t.plan(1)
+  try {
+    schema.parse('message Foo { required int32 a = 1; }\n syntax = "proto3"')
+  } catch (err) {
+    t.ok(true, 'should fail')
+  }
 })


### PR DESCRIPTION
This PR adds support for the `syntax = "proto2";` lines that prefix many protobuf files. It doesn't do anything to actually VERIFY that the syntax is followed, but at least the library doesn't crash on these anymore. :)

This should fix #12 