### PR TITLE
Resilient to use of parentheses in onfieldoptions

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -10,6 +10,10 @@ var onfieldoptions = function (tokens) {
       case ',':
         tokens.shift()
         var name = tokens.shift()
+        if (name === '(') {       // handling [(A) = B]
+          name = tokens.shift()
+          tokens.shift()          // remove the end of bracket
+        }
         if (tokens[0] !== '=') throw new Error('Unexpected token in field options: ' + tokens[0])
         tokens.shift()
         if (tokens[0] === ']') throw new Error('Unexpected ] in field option')


### PR DESCRIPTION
Here's a tiny little change to make life easier. :)