### PR TITLE
proto3 can work without optional/required

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -135,7 +135,11 @@ var onmessagebody = function (tokens) {
         break
 
       default:
-        throw new Error('Unexpected token in message: ' + tokens[0])
+        // proto3 does not require the use of optional/required, assumed as optional
+        // "singular: a well-formed message can have zero or one of this field (but not more than one)."
+        // https://developers.google.com/protocol-buffers/docs/proto3#specifying-field-rules
+        tokens.unshift('optional')
+        body.fields.push(onfield(tokens))
     }
   }
 


### PR DESCRIPTION
I'm trying to write as little code as possible to support a message schema like the following, which is copied from the spec:
```
syntax = "proto3";

message SearchRequest {
  string query = 1;
  int32 page_number = 2;
  int32 result_per_page = 3;
}
```

The parser here throws an error as it requires prefixing "required"/"optional" before those singular fields (the proto2 standard). 

So, trying to relax it with this PR :

"singular: a well-formed message can have zero or one of this field (but not more than one)."
Reference: https://developers.google.com/protocol-buffers/docs/proto3#specifying-field-rules

Pls feel free to comment, and propose what's further needed. Thanks! :)

p.s. for instance, it's better if scheme.version is accessible for the action below (but that may require your help on changing more code, perhaps in a later PR).