### PR TITLE
resolve issue #23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-buffers-schema",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "description": "No nonsense protocol buffers schema parser written in Javascript",
   "main": "index.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-buffers-schema",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "No nonsense protocol buffers schema parser written in Javascript",
   "main": "index.js",
   "devDependencies": {

--- a/parse.js
+++ b/parse.js
@@ -240,35 +240,35 @@ var onsyntaxversion = function (tokens) {
 }
 
 var onenumvalue = function (tokens) {
-  var options = {}
   if (tokens.length < 4) throw new Error('Invalid enum value: ' + tokens.slice(0, 3).join(' '))
   if (tokens[1] !== '=') throw new Error('Expected = but found ' + tokens[1])
   if (tokens[3] !== ';' && tokens[3] !== '[') throw new Error('Expected ; or [ but found ' + tokens[1])
 
   var name = tokens.shift()
   tokens.shift()
-
-  var value = Number(tokens.shift())
-
+  var val = {
+    value: null,
+    options: {}
+  }
+  val.value = Number(tokens.shift())
   if (tokens[0] === '[') {
-    options = onfieldoptions(tokens)
+    val.options = onfieldoptions(tokens)
   }
   tokens.shift() // expecting the semicolon here
 
   return {
     name: name,
-    value: value,
-    options: options
+    val: val
   }
 }
 
 var onenum = function (tokens) {
   tokens.shift()
-
+  var options = {}
   var e = {
     name: tokens.shift(),
     values: {},
-    valueoptions: {}
+    options: {}
   }
 
   if (tokens[0] !== '{') throw new Error('Expected { but found ' + tokens[0])
@@ -282,15 +282,12 @@ var onenum = function (tokens) {
       return e
     }
     if (tokens[0] === 'option') {
-      // just skip "option allow_alias = true;"
-      while (tokens.shift() !== ';') {
-        // do nothing
-      }
+      options = onoption(tokens)
+      e.options[options.name] = options.value
+      continue
     }
     var val = onenumvalue(tokens)
-    // console.log(val)
-    e.values[val.name] = val.value
-    e.valueoptions[val.name] = val.options
+    e.values[val.name] = val.val
   }
 
   throw new Error('No closing tag for enum')

--- a/parse.js
+++ b/parse.js
@@ -240,19 +240,25 @@ var onsyntaxversion = function (tokens) {
 }
 
 var onenumvalue = function (tokens) {
+  var options = {}
   if (tokens.length < 4) throw new Error('Invalid enum value: ' + tokens.slice(0, 3).join(' '))
   if (tokens[1] !== '=') throw new Error('Expected = but found ' + tokens[1])
-  if (tokens[3] !== ';') throw new Error('Expected ; but found ' + tokens[1])
+  if (tokens[3] !== ';' && tokens[3] !== '[') throw new Error('Expected ; or [ but found ' + tokens[1])
 
   var name = tokens.shift()
   tokens.shift()
 
   var value = Number(tokens.shift())
-  tokens.shift()
+
+  if (tokens[0] === '[') {
+    options = onfieldoptions(tokens)
+  }
+  tokens.shift() // expecting the semicolon here
 
   return {
     name: name,
-    value: value
+    value: value,
+    options: options
   }
 }
 
@@ -261,7 +267,8 @@ var onenum = function (tokens) {
 
   var e = {
     name: tokens.shift(),
-    values: {}
+    values: {},
+    valueoptions: {}
   }
 
   if (tokens[0] !== '{') throw new Error('Expected { but found ' + tokens[0])
@@ -281,7 +288,9 @@ var onenum = function (tokens) {
       }
     }
     var val = onenumvalue(tokens)
+    // console.log(val)
     e.values[val.name] = val.value
+    e.valueoptions[val.name] = val.options
   }
 
   throw new Error('No closing tag for enum')

--- a/stringify.js
+++ b/stringify.js
@@ -50,21 +50,33 @@ var onmessage = function (m, result) {
 
 var onenum = function (e, result) {
   result.push('enum ' + e.name + ' {')
-
-  var vals = Object.keys(e.values).map(function (key) {
-    return key + ' = ' + e.values[key] + ';'
+  if (!e.options) e.options = {}
+  var options = onoption(e.options, [])
+  if (options.length > 1) {
+    result.push(options.slice(0, -1))
+  }
+  Object.keys(e.values).map(function (v) {
+    var val = onenumvalue(e.values[v])
+    result.push([v + ' = ' + val + ';'])
   })
-
-  result.push(vals)
   result.push('}', '')
   return result
+}
+
+var onenumvalue = function (v, result) {
+  var opts = Object.keys(v.options || {}).map(function (key) {
+    return key + ' = ' + v.options[key]
+  }).join(',')
+
+  if (opts) opts = ' [' + opts + ']'
+  var val = v.value + opts
+  return val
 }
 
 var onoption = function (o, result) {
   var keys = Object.keys(o)
   keys.forEach(function (option) {
     var v = o[option]
-
     if (~option.indexOf('.')) option = '(' + option + ')'
 
     var type = typeof v
@@ -114,9 +126,7 @@ var onservices = function (s, result) {
   result.push('service ' + s.name + ' {')
 
   if (!s.options) s.options = {}
-
   onoption(s.options, result)
-
   if (!s.methods) s.methods = []
   s.methods.forEach(function (m) {
     result.push(onrpc(m, []))
@@ -178,6 +188,5 @@ module.exports = function (schema) {
       onservices(s, result)
     })
   }
-
   return result.map(indent('')).join('\n')
 }

--- a/test/fixtures/complex.json
+++ b/test/fixtures/complex.json
@@ -3,119 +3,107 @@
   "package": "tutorial",
   "imports": [],
   "enums": [],
-  "extends": [],
-  "messages": [
-    {
-      "name": "Person",
-      "extensions": null,
-      "enums": [
-        {
-          "name": "PhoneType",
-          "values": {
-            "MOBILE": 0,
-            "HOME": 1,
-            "WORK": 2
-          }
-        }
-      ],
-      "messages": [
-        {
-          "name": "PhoneNumber",
-          "enums": [],
-          "messages": [],
-          "extensions": null,
-          "fields": [
-            {
-              "name": "number",
-              "type": "string",
-              "tag": 1,
-              "map": null,
-              "oneof": null,
-              "required": true,
-              "repeated": false,
-              "options": {}
-            },
-            {
-              "name": "type",
-              "type": "PhoneType",
-              "tag": 2,
-              "map": null,
-              "oneof": null,
-              "required": false,
-              "repeated": false,
-              "options": {
-                "default": "HOME"
-              }
-            }
-          ]
-        }
-      ],
-      "fields": [
-        {
-          "name": "name",
-          "type": "string",
-          "tag": 1,
-          "map": null,
-          "oneof": null,
-          "required": true,
-          "repeated": false,
-          "options": {}
-        },
-        {
-          "name": "id",
-          "type": "int32",
-          "tag": 2,
-          "map": null,
-          "oneof": null,
-          "required": true,
-          "repeated": false,
-          "options": {}
-        },
-        {
-          "name": "email",
-          "type": "string",
-          "tag": 3,
-          "map": null,
-          "oneof": null,
-          "required": false,
-          "repeated": false,
-          "options": {}
-        },
-        {
-          "name": "phone",
-          "type": "PhoneNumber",
-          "tag": 4,
-          "map": null,
-          "oneof": null,
-          "required": false,
-          "repeated": true,
-          "options": {}
-        }
-      ]
-    },
-    {
-      "name": "AddressBook",
+  "messages": [{
+    "name": "Person",
+    "enums": [{
+      "name": "PhoneType",
+      "values": {
+        "MOBILE": 0,
+        "HOME": 1,
+        "WORK": 2
+      },
+      "valueoptions": {
+        "MOBILE": {},
+        "HOME": {},
+        "WORK": {}
+      }
+    }],
+    "messages": [{
+      "name": "PhoneNumber",
       "enums": [],
       "messages": [],
-      "extensions": null,
-      "fields": [
-        {
-          "name": "person",
-          "type": "Person",
-          "tag": 1,
-          "map": null,
-          "oneof": null,
-          "required": false,
-          "repeated": true,
-          "options": {}
+      "fields": [{
+        "name": "number",
+        "type": "string",
+        "tag": 1,
+        "map": null,
+        "oneof": null,
+        "required": true,
+        "repeated": false,
+        "options": {}
+      }, {
+        "name": "type",
+        "type": "PhoneType",
+        "tag": 2,
+        "map": null,
+        "oneof": null,
+        "required": false,
+        "repeated": false,
+        "options": {
+          "default": "HOME"
         }
-      ]
-    }
-  ],
-  "options":{
+      }],
+      "extensions": null
+    }],
+    "fields": [{
+      "name": "name",
+      "type": "string",
+      "tag": 1,
+      "map": null,
+      "oneof": null,
+      "required": true,
+      "repeated": false,
+      "options": {}
+    }, {
+      "name": "id",
+      "type": "int32",
+      "tag": 2,
+      "map": null,
+      "oneof": null,
+      "required": true,
+      "repeated": false,
+      "options": {}
+    }, {
+      "name": "email",
+      "type": "string",
+      "tag": 3,
+      "map": null,
+      "oneof": null,
+      "required": false,
+      "repeated": false,
+      "options": {}
+    }, {
+      "name": "phone",
+      "type": "PhoneNumber",
+      "tag": 4,
+      "map": null,
+      "oneof": null,
+      "required": false,
+      "repeated": true,
+      "options": {}
+    }],
+    "extensions": null
+  }, {
+    "name": "AddressBook",
+    "enums": [],
+    "messages": [],
+    "fields": [{
+      "name": "person",
+      "type": "Person",
+      "tag": 1,
+      "map": null,
+      "oneof": null,
+      "required": false,
+      "repeated": true,
+      "options": {}
+    }],
+    "extensions": null
+  }],
+  "options": {
     "java_package": "com.mafintosh.generated",
     "java_outer_classname": "Example",
     "java_generate_equals_and_hash": true,
     "optimize_for": "SPEED"
-  }
+  },
+  "extends": []
 }

--- a/test/fixtures/complex.json
+++ b/test/fixtures/complex.json
@@ -8,14 +8,24 @@
     "enums": [{
       "name": "PhoneType",
       "values": {
-        "MOBILE": 0,
-        "HOME": 1,
-        "WORK": 2
+        "MOBILE": {
+          "value": 0,
+          "options": {
+            "some_enum_option": "true"
+          }
+        },
+        "HOME": {
+          "value": 1,
+          "options": {}
+        },
+        "WORK": {
+          "value": 2,
+          "options": {}
+        }
       },
-      "valueoptions": {
-        "MOBILE": {},
-        "HOME": {},
-        "WORK": {}
+      "options": {
+        "allow_alias": true,
+        "custom_option": true
       }
     }],
     "messages": [{

--- a/test/fixtures/complex.proto
+++ b/test/fixtures/complex.proto
@@ -7,7 +7,9 @@ option optimize_for = SPEED;
 
 message Person {
   enum PhoneType {
-    MOBILE = 0;
+    option allow_alias = true;
+    option custom_option = true;
+    MOBILE = 0 [some_enum_option = true];
     HOME = 1;
     WORK = 2;
   }

--- a/test/fixtures/enum.json
+++ b/test/fixtures/enum.json
@@ -1,0 +1,29 @@
+{
+  "syntax": 3,
+  "package": null,
+  "imports": [],
+  "enums": [],
+  "messages": [{
+    "name": "Person",
+    "enums": [{
+      "name": "PhoneType",
+      "values": {
+        "MOBILE": 0,
+        "HOME": 1,
+        "WORK": 2
+      },
+      "valueoptions": {
+        "MOBILE": {
+          "enum_value_is_deprecated": "true"
+        },
+        "HOME": {},
+        "WORK": {}
+      }
+    }],
+    "messages": [],
+    "fields": [],
+    "extensions": null
+  }],
+  "options": {},
+  "extends": []
+}

--- a/test/fixtures/enum.json
+++ b/test/fixtures/enum.json
@@ -8,16 +8,27 @@
     "enums": [{
       "name": "PhoneType",
       "values": {
-        "MOBILE": 0,
-        "HOME": 1,
-        "WORK": 2
-      },
-      "valueoptions": {
         "MOBILE": {
-          "enum_value_is_deprecated": "true"
+          "value": 0,
+          "options": {
+            "enum_value_is_deprecated": "true",
+            "some_second_option": "\"value1,value2,value3\"",
+            "some_third_option": "'[value1,value2,value3]'"
+          }
         },
-        "HOME": {},
-        "WORK": {}
+        "HOME": {
+          "value": 1,
+          "options": {
+            "enum_value_is_deprecated": "true"
+          }
+        },
+        "WORK": {
+          "value": 2,
+          "options": {}
+        }
+      },
+      "options": {
+        "allow_alias": true
       }
     }],
     "messages": [],

--- a/test/fixtures/enum.proto
+++ b/test/fixtures/enum.proto
@@ -1,8 +1,8 @@
 message Person {
   enum PhoneType {
     option allow_alias = true;
-    MOBILE = 0 [(enum_value_is_deprecated) = true];
-    HOME = 1;
+    MOBILE = 0 [(enum_value_is_deprecated) = true, (some_second_option) = "value1, value2, value3", (some_third_option) = '[value1, value2, value3]'];
+    HOME = 1 [(enum_value_is_deprecated) = true];
     WORK = 2;
   }
 }

--- a/test/fixtures/enum.proto
+++ b/test/fixtures/enum.proto
@@ -1,0 +1,8 @@
+message Person {
+  enum PhoneType {
+    option allow_alias = true;
+    MOBILE = 0 [(enum_value_is_deprecated) = true];
+    HOME = 1;
+    WORK = 2;
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -108,3 +108,8 @@ tape('service parse + stringify', function (t) {
   t.same(schema.stringify(schema.parse(fixture('service.proto'))), syntax + fixture('service.proto'))
   t.end()
 })
+
+tape('enums with options', function (t) {
+  t.same(schema.parse(fixture('enum.proto')), require('./fixtures/enum.json'))
+  t.end()
+})


### PR DESCRIPTION
I've added a new field to enum delcarations, "valueoptions". We don't want to use "options", as enum options would conflict that and even though they are entirely skipped now there is no guarantee that we would want to continue to skip them in the future.

Optimally if we were writing from scratch we would roll the enum value values and the enum value options together into a single object, but such a change could break code for people who use that field currently. As such, I've kept them separate to preserve backwards compatibility.

Tests updated.