### PR TITLE
throw when a message declares packed fields of types that cannot be packed

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -1,6 +1,18 @@
 var tokenize = require('./tokenize')
 var MAX_RANGE = 0x1FFFFFFF
 
+// "Only repeated fields of primitive numeric types (types which use the varint, 32-bit, or 64-bit wire types) can be declared "packed"."
+// https://developers.google.com/protocol-buffers/docs/encoding#optional
+var PACKABLE_TYPES = [
+  // varint wire types
+  'int32', 'int64', 'uint32', 'uint64', 'sint32', 'sint64', 'bool',
+  // + ENUMS
+  // 64-bit wire types
+  'fixed64', 'sfixed64', 'double',
+  // 32-bit wire types
+  'fixed32', 'sfixed32', 'float'
+]
+
 var onfieldoptions = function (tokens) {
   var opts = {}
 
@@ -605,6 +617,47 @@ var parse = function (buf) {
           }
           msg.fields.push(field)
         })
+      }
+    })
+  })
+
+  schema.messages.forEach(function (msg) {
+    msg.fields.forEach(function (field) {
+      if (field.options && field.options.packed === 'true') {
+        if (PACKABLE_TYPES.indexOf(field.type) === -1) {
+          // let's see if it's an enum
+          if (field.type.indexOf('.') === -1) {
+            if (msg.enums && msg.enums.some(function (en) {
+              return en.name === field.type
+            })) {
+              return
+            }
+          } else {
+            var fieldSplit = field.type.split('.')
+            if (fieldSplit.length > 2) {
+              throw new Error('what is this?')
+            }
+
+            var messageName = fieldSplit[0]
+            var enumName = fieldSplit[1]
+
+            var message
+            schema.messages.some(function (msg) {
+              if (msg.name === messageName) {
+                message = msg
+                return msg
+              }
+            })
+
+            if (message && message.enums && message.enums.some(function (en) {
+              return en.name === enumName
+            })) {
+              return
+            }
+          }
+
+          throw new Error('Fields of type ' + field.type + ' cannot be declared [packed=true]. Only repeated fields of primitive numeric types (types which use the varint, 32-bit, or 64-bit wire types) can be declared "packed". See https://developers.google.com/protocol-buffers/docs/encoding#optional')
+        }
       }
     })
   })

--- a/test/fixtures/pheromon-trajectories.proto
+++ b/test/fixtures/pheromon-trajectories.proto
@@ -1,0 +1,8 @@
+message deviceTrajectory {
+  required bytes dates = 1 [packed=true];
+  required bytes signal_strengths = 2 [packed=true];
+}
+
+message trajectories {
+    repeated deviceTrajectory trajectories = 1 [packed=true];
+}

--- a/test/fixtures/valid-packed.proto
+++ b/test/fixtures/valid-packed.proto
@@ -1,0 +1,35 @@
+message EnumCarrying{
+  enum E{
+    A = 0;
+    B = 1;
+  }
+
+}
+
+message ValidPacked {
+  // varint wire types
+  repeated int32 f1 = 1 [packed = true];
+  repeated int64 f2 = 2 [packed = true];
+  repeated uint32 f3 = 3 [packed = true];
+  repeated uint64 f4 = 4 [packed = true];
+  repeated sint32 f5 = 5 [packed = true];
+  repeated sint64 f6 = 6 [packed = true];
+  repeated bool f7 = 7 [packed = true];
+  enum Corpus {
+    UNIVERSAL = 0;
+    WEB = 1;
+  }
+  repeated Corpus f8 = 8 [packed = true];
+  repeated EnumCarrying.E f9 = 9 [packed = true];
+  
+  // 64-bit wire types
+  repeated fixed64 f10 = 10 [packed = true];
+  repeated sfixed64 f11 = 11 [packed = true];
+  repeated double f12 = 12 [packed = true];
+  
+  // 32-bit wire types
+  repeated fixed32 f13 = 13 [packed = true];
+  repeated sfixed32 f14 = 14 [packed = true];
+  repeated float f15 = 15 [packed = true];
+}
+  

--- a/test/index.js
+++ b/test/index.js
@@ -113,3 +113,17 @@ tape('enums with options', function (t) {
   t.same(schema.parse(fixture('enum.proto')), require('./fixtures/enum.json'))
   t.end()
 })
+
+tape('varint, 64-bit and 32-bit wire types can be packed', function (t) {
+  t.doesNotThrow(function () {
+    schema.parse(fixture('valid-packed.proto'))
+  }, 'should not throw')
+  t.end()
+})
+
+tape('non-primitive packed should throw', function (t) {
+  t.throws(function () {
+    schema.parse(fixture('pheromon-trajectories.proto'))
+  }, 'should throw')
+  t.end()
+})


### PR DESCRIPTION
I'm sending this PR more as the beginning of a discussion than an actual contribution at this point.

Addressing https://github.com/mafintosh/protocol-buffers/issues/49

This PR contains 2 tests for packed fields and the corresponding code that throws when it should.
I did my best to follow the style guide.
The multiple `.some` calls can end up traversing all messages and all enums. I'm not sure there is a better way in the current state of things. The way to improve perf would be to keep a map of messages/enums key'd on names. But I doubt it's really necessary.

Please tell me what you think.
