### PR TITLE
Parse extends inside messages.

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -96,6 +96,7 @@ var onmessagebody = function (tokens) {
     enums: [],
     messages: [],
     fields: [],
+    extends: [],
     extensions: null
   }
 
@@ -132,6 +133,10 @@ var onmessagebody = function (tokens) {
           body.fields.push(field)
         }
         tokens.shift()
+        break
+
+      case 'extend':
+        body.extends.push(onextend(tokens))
         break
 
       case ';':
@@ -178,6 +183,7 @@ var onmessage = function (tokens) {
   var msg = {
     name: tokens.shift(),
     enums: [],
+    extends: [],
     messages: [],
     fields: []
   }
@@ -195,6 +201,7 @@ var onmessage = function (tokens) {
       msg.enums = body.enums
       msg.messages = body.messages
       msg.fields = body.fields
+      msg.extends = body.extends
       msg.extensions = body.extensions
       return msg
     }

--- a/test/fixtures/basic.json
+++ b/test/fixtures/basic.json
@@ -8,6 +8,7 @@
     {
       "name": "Point",
       "enums": [],
+      "extends": [],
       "messages": [],
       "extensions": null,
       "fields": [
@@ -46,6 +47,7 @@
     {
       "name": "Line",
       "enums": [],
+      "extends": [],
       "extensions": null,
       "messages": [],
       "fields": [

--- a/test/fixtures/comments.json
+++ b/test/fixtures/comments.json
@@ -8,6 +8,7 @@
     {
       "name": "Point",
       "enums": [],
+      "extends": [],
       "messages": [],
       "extensions": null,
       "fields": [
@@ -46,6 +47,7 @@
     {
       "name": "Line",
       "enums": [],
+      "extends": [],
       "extensions": null,
       "messages": [],
       "fields": [
@@ -84,6 +86,7 @@
     {
       "name": "A",
       "enums": [],
+      "extends": [],
       "messages": [],
       "fields": [],
       "extensions": null

--- a/test/fixtures/complex.json
+++ b/test/fixtures/complex.json
@@ -28,9 +28,11 @@
         "custom_option": true
       }
     }],
+    "extends": [],
     "messages": [{
       "name": "PhoneNumber",
       "enums": [],
+      "extends": [],
       "messages": [],
       "fields": [{
         "name": "number",
@@ -96,6 +98,7 @@
   }, {
     "name": "AddressBook",
     "enums": [],
+    "extends": [],
     "messages": [],
     "fields": [{
       "name": "person",

--- a/test/fixtures/enum.json
+++ b/test/fixtures/enum.json
@@ -31,6 +31,7 @@
         "allow_alias": true
       }
     }],
+    "extends": [],
     "messages": [],
     "fields": [],
     "extensions": null

--- a/test/fixtures/extend.json
+++ b/test/fixtures/extend.json
@@ -7,6 +7,7 @@
     {
       "name": "MsgNormal",
       "enums": [],
+      "extends": [],
       "messages": [],
       "fields": [
         {
@@ -65,6 +66,7 @@
     {
       "name": "MsgExtend",
       "enums": [],
+      "extends": [],
       "messages": [],
       "fields": [
         {
@@ -131,6 +133,7 @@
       "message": {
         "name": "MsgExtend",
         "enums": [],
+        "extends": [],
         "messages": [],
         "fields": [
           {

--- a/test/fixtures/map.json
+++ b/test/fixtures/map.json
@@ -7,6 +7,7 @@
     {
       "name": "Data",
       "enums": [],
+      "extends": [],
       "messages": [],
       "fields": [
         {

--- a/test/fixtures/oneof.json
+++ b/test/fixtures/oneof.json
@@ -7,6 +7,7 @@
     {
       "name": "SampleMessage",
       "enums": [],
+      "extends": [],
       "messages": [],
       "fields": [
         {

--- a/test/fixtures/options.json
+++ b/test/fixtures/options.json
@@ -6,6 +6,7 @@
   "messages": [{
     "name": "OptionFields",
     "enums": [],
+    "extends": [],
     "messages": [],
     "fields": [{
       "name": "type",
@@ -23,6 +24,7 @@
   }, {
     "name": "MoreOptionFields",
     "enums": [],
+    "extends": [],
     "messages": [],
     "fields": [{
       "name": "values",

--- a/test/fixtures/search.json
+++ b/test/fixtures/search.json
@@ -9,6 +9,7 @@
 			"name": "SearchResponse",
 			"extensions": null,
 			"enums": [],
+			"extends": [],
 			"messages": [],
 			"fields": [
 				{

--- a/test/fixtures/service.json
+++ b/test/fixtures/service.json
@@ -9,6 +9,7 @@
 		  "name": "HelloRequest",
 		  "extensions": null,
 		  "enums": [],
+		  "extends": [],
 		  "messages": [],
 		  "fields": [
 				{
@@ -27,6 +28,7 @@
 		  "name": "HelloResponse",
 		  "extensions": null,
 		  "enums": [],
+		  "extends": [],
 		  "messages": [],
 		  "fields": [
 				{

--- a/test/fixtures/version.json
+++ b/test/fixtures/version.json
@@ -8,6 +8,7 @@
     {
       "name": "Point",
       "enums": [],
+      "extends": [],
       "messages": [],
       "extensions": null,
       "fields": [
@@ -46,6 +47,7 @@
     {
       "name": "Line",
       "enums": [],
+      "extends": [],
       "extensions": null,
       "messages": [],
       "fields": [


### PR DESCRIPTION
According to https://developers.google.com/protocol-buffers/docs/proto#nested-extensions it should be possible to use `extend` within a `message` block.