### PR TITLE
Don't break parseing on reserved keyword

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -146,6 +146,13 @@ var onmessagebody = function (tokens) {
         tokens.shift()
         break
 
+      case 'reserved':
+        tokens.shift()
+        while (tokens[0] !== ';') {
+          tokens.shift()
+        }
+        break
+
       default:
         // proto3 does not require the use of optional/required, assumed as optional
         // "singular: a well-formed message can have zero or one of this field (but not more than one)."

--- a/test/fixtures/reserved.json
+++ b/test/fixtures/reserved.json
@@ -1,0 +1,39 @@
+{
+  "syntax": 3,
+  "package": null,
+  "imports": [],
+  "enums": [],
+  "extends": [],
+  "options": {},
+  "messages": [
+		{
+		  "name": "Reserved",
+		  "extensions": null,
+		  "enums": [],
+		  "extends": [],
+		  "messages": [],
+		  "fields": [
+				{
+			    "name": "x",
+			    "type": "string",
+			    "tag": 1,
+			    "map": null,
+			    "oneof": null,
+			    "required": false,
+			    "repeated": false,
+			    "options": {}
+			  },
+        {
+			    "name": "y",
+			    "type": "string",
+			    "tag": 10,
+			    "map": null,
+			    "oneof": null,
+			    "required": false,
+			    "repeated": false,
+			    "options": {}
+			  }
+			]
+		}
+  ]
+}

--- a/test/fixtures/reserved.proto
+++ b/test/fixtures/reserved.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+message Reserved {
+  string x = 1;
+  reserved 2, 3;
+  reserved 5 to 9;
+  reserved "foo", "bar";
+  string y = 10;
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -120,3 +120,8 @@ tape('fail on no tags', function (t) {
   })
   t.end()
 })
+
+tape('reserved', function (t) {
+  t.same(schema.parse(fixture('reserved.proto')), require('./fixtures/reserved.json'))
+  t.end()
+})


### PR DESCRIPTION
Parse can now handle the reserved keyword and will ignore it. Solution for:
https://github.com/mafintosh/protocol-buffers-schema/issues/32