### PR TITLE
#34 ignore 'option' keyword, jsut as we ignored 'reserved'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-buffers-schema",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "No nonsense protocol buffers schema parser written in Javascript",
   "main": "index.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-buffers-schema",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "description": "No nonsense protocol buffers schema parser written in Javascript",
   "main": "index.js",
   "devDependencies": {

--- a/parse.js
+++ b/parse.js
@@ -147,6 +147,7 @@ var onmessagebody = function (tokens) {
         break
 
       case 'reserved':
+      case 'option':
         tokens.shift()
         while (tokens[0] !== ';') {
           tokens.shift()


### PR DESCRIPTION
I simply ignored the `option` keyword altogether, like you did for `reserved`. 

If this is ok for you, can you do a 3.2.1 release after merging this into master ?

Thanks