### PR TITLE
Support option with dot

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -351,6 +351,11 @@ var onoption = function (tokens) {
           if (tokens[0] !== ')') throw new Error('Expected ) but found ' + tokens[0])
           tokens.shift()
         }
+
+        if (tokens[0][0] === '.') {
+          name += tokens.shift()
+        }
+
         break
 
       case '=':

--- a/test/fixtures/option.json
+++ b/test/fixtures/option.json
@@ -1,0 +1,256 @@
+{
+  "syntax": 3,
+  "package": null,
+  "imports": [
+    "google/protobuf/descriptor.proto"
+  ],
+  "enums": [
+    {
+      "name": "MyEnum",
+      "values": {
+        "FOO": {
+          "value": 1,
+          "options": {
+            "my_enum_value_option": "321"
+          }
+        },
+        "BAR": {
+          "value": 2,
+          "options": {}
+        }
+      },
+      "options": {
+        "my_enum_option": true
+      }
+    }
+  ],
+  "messages": [
+    {
+      "name": "MyMessage",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "foo",
+          "type": "int32",
+          "tag": 1,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {
+            "my_field_option": "4.5"
+          }
+        },
+        {
+          "name": "bar",
+          "type": "string",
+          "tag": 2,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        }
+      ],
+      "extensions": null
+    },
+    {
+      "name": "RequestType",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [],
+      "extensions": null
+    },
+    {
+      "name": "ResponseType",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [],
+      "extensions": null
+    }
+  ],
+  "options": {
+    "my_file_option": "Helloworld!"
+  },
+  "extends": [
+    {
+      "name": "google.protobuf.FileOptions",
+      "message": {
+        "name": "google.protobuf.FileOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_file_option",
+            "type": "string",
+            "tag": 50000,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    },
+    {
+      "name": "google.protobuf.MessageOptions",
+      "message": {
+        "name": "google.protobuf.MessageOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_message_option",
+            "type": "int32",
+            "tag": 50001,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    },
+    {
+      "name": "google.protobuf.FieldOptions",
+      "message": {
+        "name": "google.protobuf.FieldOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_field_option",
+            "type": "float",
+            "tag": 50002,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    },
+    {
+      "name": "google.protobuf.EnumOptions",
+      "message": {
+        "name": "google.protobuf.EnumOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_enum_option",
+            "type": "bool",
+            "tag": 50003,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    },
+    {
+      "name": "google.protobuf.EnumValueOptions",
+      "message": {
+        "name": "google.protobuf.EnumValueOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_enum_value_option",
+            "type": "uint32",
+            "tag": 50004,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    },
+    {
+      "name": "google.protobuf.ServiceOptions",
+      "message": {
+        "name": "google.protobuf.ServiceOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_service_option",
+            "type": "MyEnum",
+            "tag": 50005,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    },
+    {
+      "name": "google.protobuf.MethodOptions",
+      "message": {
+        "name": "google.protobuf.MethodOptions",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "my_method_option",
+            "type": "MyMessage",
+            "tag": 50006,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null
+      }
+    }
+  ],
+  "services": [
+    {
+      "name": "MyService",
+      "methods": [
+        {
+          "name": "MyMethod",
+          "input_type": "RequestType",
+          "output_type": "ResponseType",
+          "client_streaming": false,
+          "server_streaming": false,
+          "options": {
+            "my_method_option.foo": "567",
+            "my_method_option.bar": "Somestring"
+          }
+        }
+      ],
+      "options": {
+        "my_service_option": "FOO"
+      }
+    }
+  ]
+}

--- a/test/fixtures/option.proto
+++ b/test/fixtures/option.proto
@@ -1,0 +1,53 @@
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FileOptions {
+  optional string my_file_option = 50000;
+}
+extend google.protobuf.MessageOptions {
+  optional int32 my_message_option = 50001;
+}
+extend google.protobuf.FieldOptions {
+  optional float my_field_option = 50002;
+}
+extend google.protobuf.EnumOptions {
+  optional bool my_enum_option = 50003;
+}
+extend google.protobuf.EnumValueOptions {
+  optional uint32 my_enum_value_option = 50004;
+}
+extend google.protobuf.ServiceOptions {
+  optional MyEnum my_service_option = 50005;
+}
+extend google.protobuf.MethodOptions {
+  optional MyMessage my_method_option = 50006;
+}
+
+option (my_file_option) = "Hello world!";
+
+message MyMessage {
+  option (my_message_option) = 1234;
+
+  optional int32 foo = 1 [(my_field_option) = 4.5];
+  optional string bar = 2;
+}
+
+enum MyEnum {
+  option (my_enum_option) = true;
+
+  FOO = 1 [(my_enum_value_option) = 321];
+  BAR = 2;
+}
+
+message RequestType {}
+message ResponseType {}
+
+service MyService {
+  option (my_service_option) = FOO;
+
+  rpc MyMethod(RequestType) returns(ResponseType) {
+    // Note:  my_method_option has type MyMessage.  We can set each field
+    //   within it using a separate "option" line.
+    option (my_method_option).foo = 567;
+    option (my_method_option).bar = "Some string";
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -139,3 +139,8 @@ tape('non-primitive packed should throw', function (t) {
   }, 'should throw')
   t.end()
 })
+
+tape('custom options parse', function (t) {
+  t.same(schema.parse(fixture('option.proto')), require('./fixtures/option.json'))
+  t.end()
+})


### PR DESCRIPTION
Support use a custom message type of one option. 
In old version, there are something wrong when parse file like this:
```proto
extend google.protobuf.MethodOptions {
  optional MyMessage my_method_option = 50006;
}

message MyMessage {
  optional int32 foo = 1;
  optional string bar = 2;
}

message RequestType {}
message ResponseType {}

service MyService {
  rpc MyMethod(RequestType) returns(ResponseType) {
    option (my_method_option).foo = 567;
    option (my_method_option).bar = "Some string";
  }
}
```
code from https://developers.google.com/protocol-buffers/docs/proto#options
