### PR TITLE
Fix option map field value with semicolon

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -417,6 +417,10 @@ var onoptionMap = function (tokens) {
         }
 
         map[key] = value
+
+        if (tokens[0] === ';') {
+          tokens.shift()
+        }
         break
 
       case '{':

--- a/test/fixtures/option.json
+++ b/test/fixtures/option.json
@@ -249,7 +249,10 @@
         }
       ],
       "options": {
-        "my_service_option": "FOO"
+        "my_service_option": "FOO",
+        "my_service_option_map": {
+          "foo": "bar"
+        }
       }
     }
   ]

--- a/test/fixtures/option.proto
+++ b/test/fixtures/option.proto
@@ -43,6 +43,9 @@ message ResponseType {}
 
 service MyService {
   option (my_service_option) = FOO;
+  option (my_service_option_map) = {
+    foo: "bar";
+  };
 
   rpc MyMethod(RequestType) returns(ResponseType) {
     // Note:  my_method_option has type MyMessage.  We can set each field


### PR DESCRIPTION
I got an error when option is a map and field value is end with a semicolon.
```javascript
option (my_service_option_map) = {
    foo: "bar";
  };
```
I add modify the onoptionMap method, shift the semicolon code. Then work fine.