### PR TITLE
allow option objects in protobuf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-buffers-schema",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "No nonsense protocol buffers schema parser written in Javascript",
   "main": "index.js",
   "devDependencies": {

--- a/parse.js
+++ b/parse.js
@@ -13,6 +13,31 @@ var PACKABLE_TYPES = [
   'fixed32', 'sfixed32', 'float'
 ]
 
+var onfieldoptionsvalue = function (tokens) {
+  if (tokens[0] !== '{') return tokens.shift()
+  var opts = {}
+  while (tokens.length) {
+    switch (tokens[0]) {
+      case '{':
+      case ',':
+        tokens.shift()
+        if (tokens[0] === '}') break
+        var name = tokens.shift()
+        if (tokens[0] !== ':') throw new Error(`Unexpected token in field options value: ${tokens}`)
+        tokens.shift()
+        if (tokens[0] === '}') throw new Error('Unexpected } in field options value')
+        opts[name] = onfieldoptionsvalue(tokens)
+        break
+      case '}':
+        tokens.shift()
+        return opts
+
+      default:
+        throw new Error(`Unexpected token in field options value: ${tokens}`)
+    }
+  }
+}
+
 var onfieldoptions = function (tokens) {
   var opts = {}
 
@@ -29,7 +54,7 @@ var onfieldoptions = function (tokens) {
         if (tokens[0] !== '=') throw new Error('Unexpected token in field options: ' + tokens[0])
         tokens.shift()
         if (tokens[0] === ']') throw new Error('Unexpected ] in field option')
-        opts[name] = tokens.shift()
+        opts[name] = onfieldoptionsvalue(tokens)
         break
       case ']':
         tokens.shift()

--- a/test/fixtures/options.json
+++ b/test/fixtures/options.json
@@ -3,43 +3,75 @@
   "package": null,
   "imports": [],
   "enums": [],
-  "messages": [{
-    "name": "OptionFields",
-    "enums": [],
-    "extends": [],
-    "messages": [],
-    "fields": [{
-      "name": "type",
-      "type": "string",
-      "tag": 2,
-      "map": null,
-      "oneof": null,
-      "required": false,
-      "repeated": false,
-      "options": {
-        "mylist": "\"some,values,[here]\""
-      }
-    }],
-    "extensions": null
-  }, {
-    "name": "MoreOptionFields",
-    "enums": [],
-    "extends": [],
-    "messages": [],
-    "fields": [{
-      "name": "values",
-      "type": "string",
-      "tag": 3,
-      "map": null,
-      "oneof": null,
-      "required": false,
-      "repeated": false,
-      "options": {
-        "mylist2": "'[more,values],[here]'"
-      }
-    }],
-    "extensions": null
-  }],
+  "messages": [
+    {
+      "name": "OptionFields",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "type",
+          "type": "string",
+          "tag": 2,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {
+            "mylist": "\"some,values,[here]\""
+          }
+        }
+      ],
+      "extensions": null
+    },
+    {
+      "name": "MoreOptionFields",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "values",
+          "type": "string",
+          "tag": 3,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {
+            "mylist2": "'[more,values],[here]'"
+          }
+        }
+      ],
+      "extensions": null
+    },
+    {
+      "name": "MoreMoreOptionFields",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "values",
+          "type": "string",
+          "tag": 4,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {
+            "myobject": {
+              "option1": "\"123\"",
+              "option2": "123",
+              "option3": "false"
+            }
+          }
+        }
+      ],
+      "extensions": null
+    }
+  ],
   "options": {},
   "extends": []
 }

--- a/test/fixtures/options.proto
+++ b/test/fixtures/options.proto
@@ -6,3 +6,7 @@ message OptionFields {
 message MoreOptionFields {
   optional string values = 3 [mylist2 = '[more, values], [here]'];
 }
+
+message MoreMoreOptionFields {
+  optional string values = 4 [(myobject) = { option1: "123", option2: 123, option3: false, }];
+}


### PR DESCRIPTION
Parse
```
message MoreMoreOptionFields {
  optional string values = 4 [(myobject) = { option1: "123", option2: 123, option3: false, }];
}
```