### PR TITLE
Fixed bug with map field stringifying

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -8,8 +8,7 @@ var onfield = function (f, result) {
   }).join(',')
 
   if (opts) opts = ' [' + opts + ']'
-
-  result.push((prefix ? prefix + ' ' : '') + (f.map === 'map' ? '' : f.type + ' ') + f.name + ' = ' + f.tag + opts + ';')
+  result.push((prefix ? prefix + ' ' : '') + (f.map ? '' : f.type + ' ') + f.name + ' = ' + f.tag + opts + ';')
   return result
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,13 @@ tape('schema with map', function (t) {
   t.end()
 })
 
+tape('schema with map + stringify', function (t) {
+  var mapFixture = fixture('map.proto')
+  var stringified = schema.stringify(schema.parse(mapFixture)).slice('syntax = "proto3";\n'.length).trim()
+  t.same(stringified, mapFixture.trim())
+  t.end()
+})
+
 tape('schema with syntax version', function (t) {
   t.same(schema.parse(fixture('version.proto')), require('./fixtures/version.json'))
   t.end()


### PR DESCRIPTION
Map fields are currently stringified with an extra `map` token, which is invalid syntax, i.e.:

```
message Data {
  map<string, string> something = 1;
}
```
When parsed + stringified produces:
```
message Data {
  map<string, string> map something = 1;
}
```
This PR fixes `stringify` for `map` fields, and includes a test that  fails on master.