### PR TITLE
Allowing protobuf version and import statements in .proto files to use single quotes in addition to double quotes

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -251,11 +251,11 @@ var onsyntaxversion = function (tokens) {
 
   var version = tokens.shift()
   switch (version) {
-    case '"proto2"':
+    case '"proto2"': case "'proto2'":
       version = 2
       break
 
-    case '"proto3"':
+    case '"proto3"': case "'proto3'":
       version = 3
       break
 
@@ -443,7 +443,7 @@ var onoptionMap = function (tokens) {
 
 var onimport = function (tokens) {
   tokens.shift()
-  var file = tokens.shift().replace(/^"+|"+$/gm, '')
+  var file = tokens.shift().replace(/^['"]+|['"]+$/gm, '')
 
   if (tokens[0] !== ';') throw new Error('Unexpected token: ' + tokens[0] + '. Expected ";"')
 


### PR DESCRIPTION
Allowing protobuf version and import statements in .proto files to use single single quotes instead of only double quotes (e.g. allow _version = 'proto2';_, which is supported by the google javascript protoc compiler but not by this package). This is just a QoL improvement, and should not have a functional impact- it just lets users who have .proto files using single quotes where allowed by the protoc compiler to not have to change them in order to use this package.