### PR TITLE
Support escaped quotes in field option value

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -571,7 +571,7 @@ var parse = function (buf) {
       // look ahead for the closing quote and collapse all
       // in-between tokens into a single token
       for (j; j < tokens.length; j++) {
-        if (/^([^'"]*)("|')$/.test(tokens[j])) {
+        if (/^[^'"\\]*(?:\\.[^'"\\]*)*("|')$/.test(tokens[j])) {
           tokens = tokens.slice(0, i).concat(tokens.slice(i, j + 1).join('')).concat(tokens.slice(j + 1))
           break
         }

--- a/test/fixtures/escaped-quotes.json
+++ b/test/fixtures/escaped-quotes.json
@@ -1,0 +1,31 @@
+{                                                           
+    "syntax": 3,                                              
+    "package": null,                                          
+    "imports": [],                                            
+    "enums": [],                                              
+    "messages": [                                             
+      {                                                       
+        "name": "Event",                                      
+        "enums": [],                                          
+        "extends": [],                                        
+        "messages": [],                                       
+        "fields": [                                           
+          {                                                   
+            "name": "id",                                     
+            "type": "EntityId",                               
+            "tag": 1,                                         
+            "map": null,                                      
+            "oneof": null,                                    
+            "required": false,                                
+            "repeated": false,                                
+            "options": {                                      
+              "tagger.tags": "\"bson:\\\"_id,omitempty\\\"\"" 
+            }                                                 
+          }                                                   
+        ],                                                    
+        "extensions": null                                    
+      }                                                       
+    ],                                                        
+    "options": {},                                            
+    "extends": []                                             
+  }                                                           

--- a/test/fixtures/escaped-quotes.proto
+++ b/test/fixtures/escaped-quotes.proto
@@ -1,0 +1,3 @@
+message Event {
+    EntityId id = 1 [(tagger.tags) = "bson:\"_id,omitempty\"" ];
+}

--- a/test/index.js
+++ b/test/index.js
@@ -144,3 +144,8 @@ tape('custom options parse', function (t) {
   t.same(schema.parse(fixture('option.proto')), require('./fixtures/option.json'))
   t.end()
 })
+
+tape('escaped quotes in option value parse', function (t) {
+  t.same(schema.parse(fixture('escaped-quotes.proto')), require('./fixtures/escaped-quotes.json'))
+  t.end()
+})


### PR DESCRIPTION
Brings correct parsing escaped quotes in field option value, example is below.
```proto
message Event {
    EntityId id = 1 [(tagger.tags) = "bson:\"_id,omitempty\"" ];
}
```
Before this PR such values caused errors.