### PR TITLE
Replace Buffer with Uint8Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Running the above example will print something like
 
 ## API
 
-#### `schema.parse(protobufSchemaBufferOrString)`
+#### `schema.parse(protobufSchemaAsStringOrUint8Array)`
 
 Parses a .proto schema into a javascript object
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "No nonsense protocol buffers schema parser written in Javascript",
   "main": "index.js",
   "devDependencies": {
-    "standard": "^10.0.3",
+    "standard": "^14.3.4",
     "tape": "^4.8.0"
   },
   "scripts": {

--- a/parse.js
+++ b/parse.js
@@ -565,8 +565,11 @@ var onrpc = function (tokens) {
   throw new Error('No closing tag for rpc')
 }
 
-var parse = function (buf) {
-  var tokens = tokenize(buf.toString())
+var parse = function (input) {
+  var source = typeof input === 'string'
+    ? input
+    : new TextDecoder().decode(input)
+  var tokens = tokenize(source)
   // check for isolated strings in tokens by looking for opening quote
   for (var i = 0; i < tokens.length; i++) {
     if (/^("|')([^'"]*)$/.test(tokens[i])) {

--- a/test/index.js
+++ b/test/index.js
@@ -7,8 +7,18 @@ var fixture = function (name) {
   return fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf-8')
 }
 
+var fixtureBytes = function (name) {
+  var content = fs.readFileSync(path.join(__dirname, 'fixtures', name))
+  return new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
+}
+
 tape('basic parse', function (t) {
   t.same(schema.parse(fixture('basic.proto')), require('./fixtures/basic.json'))
+  t.end()
+})
+
+tape('basic parse (bytes)', function (t) {
+  t.same(schema.parse(fixtureBytes('basic.proto')), require('./fixtures/basic.json'))
   t.end()
 })
 
@@ -20,6 +30,11 @@ tape('basic parse + stringify', function (t) {
 
 tape('complex parse', function (t) {
   t.same(schema.parse(fixture('complex.proto')), require('./fixtures/complex.json'))
+  t.end()
+})
+
+tape('complex parse (bytes)', function (t) {
+  t.same(schema.parse(fixtureBytes('complex.proto')), require('./fixtures/complex.json'))
   t.end()
 })
 


### PR DESCRIPTION
Fixes #52 

Had to upgrade standard because older version complained about use of `TextDecoder`.