### PR TITLE
chore: moving to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: lts/*
+    - run: npm -v
+    - run: npm i
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - '0.10'
-  - '0.12'
-  - '4'
-  - '5'
-  - 'node'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ No nonsense [protocol buffers](https://developers.google.com/protocol-buffers) s
 npm install protocol-buffers-schema
 ```
 
-[![build status](http://img.shields.io/travis/mafintosh/protocol-buffers-schema.svg?style=flat)](http://travis-ci.org/mafintosh/protocol-buffers-schema)
+[![build status](https://github.com/mafintosh/protocol-buffers-schema/actions/workflows/test.yml/badge.svg)](https://github.com/mafintosh/protocol-buffers-schema/workflows/test.yml)
 
 ## Usage
 


### PR DESCRIPTION
For better visibility of the ci tests run.

It use `lts/*` same as https://github.com/mafintosh/protocol-buffers/pull/84#issuecomment-1075288588

Successful run here: https://github.com/martinheidegger/protocol-buffers-schema/actions/runs/2026160870
