### PR TITLE
Expose presence of explicit optional keyword on fields

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -123,9 +123,11 @@ var onfield = function (tokens) {
       case 'repeated':
       case 'required':
       case 'optional':
+      case 'implicit-optional':
         var t = tokens.shift()
         field.required = t === 'required'
         field.repeated = t === 'repeated'
+        if (t === 'optional') { field.optional = true }
         field.type = tokens.shift()
         field.name = tokens.shift()
         break
@@ -219,7 +221,7 @@ var onmessagebody = function (tokens) {
         // proto3 does not require the use of optional/required, assumed as optional
         // "singular: a well-formed message can have zero or one of this field (but not more than one)."
         // https://developers.google.com/protocol-buffers/docs/proto3#specifying-field-rules
-        tokens.unshift('optional')
+        tokens.unshift('implicit-optional')
         body.fields.push(onfield(tokens))
     }
   }

--- a/test/fixtures/basic.json
+++ b/test/fixtures/basic.json
@@ -41,6 +41,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ]
@@ -81,6 +82,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ]

--- a/test/fixtures/comments.json
+++ b/test/fixtures/comments.json
@@ -41,6 +41,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ]
@@ -81,6 +82,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ]

--- a/test/fixtures/complex.json
+++ b/test/fixtures/complex.json
@@ -53,6 +53,7 @@
         "oneof": null,
         "required": false,
         "repeated": false,
+        "optional": true,
         "options": {
           "default": "HOME"
         }
@@ -85,6 +86,7 @@
       "oneof": null,
       "required": false,
       "repeated": false,
+      "optional": true,
       "options": {}
     }, {
       "name": "phone",

--- a/test/fixtures/extend.json
+++ b/test/fixtures/extend.json
@@ -29,6 +29,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         },
         {
@@ -49,6 +50,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         },
         {
@@ -59,6 +61,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ],
@@ -89,6 +92,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         },
         {
@@ -109,6 +113,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         },
         {
@@ -119,6 +124,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ],
@@ -147,6 +153,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           },
           {
@@ -157,6 +164,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],

--- a/test/fixtures/oneof.json
+++ b/test/fixtures/oneof.json
@@ -19,6 +19,7 @@
           "oneof": "test_oneof",
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         },
         {
@@ -29,6 +30,7 @@
           "oneof": "test_oneof",
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
 

--- a/test/fixtures/option.json
+++ b/test/fixtures/option.json
@@ -42,6 +42,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {
             "my_field_option": "4.5"
           }
@@ -54,6 +55,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ],
@@ -92,6 +94,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         },
         {
@@ -102,6 +105,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ],
@@ -122,6 +126,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {
             "foo_options": {
               "opt1": "123",
@@ -137,6 +142,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {
             "foo_options": {
               "opt1": "123",
@@ -169,6 +175,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -192,6 +199,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -215,6 +223,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -238,6 +247,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -261,6 +271,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -284,6 +295,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -307,6 +319,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],
@@ -330,6 +343,7 @@
             "oneof": null,
             "required": false,
             "repeated": false,
+            "optional": true,
             "options": {}
           }
         ],

--- a/test/fixtures/options.json
+++ b/test/fixtures/options.json
@@ -17,6 +17,7 @@
       "oneof": null,
       "required": false,
       "repeated": false,
+      "optional": true,
       "options": {
         "mylist": "\"some,values,[here]\""
       }
@@ -36,6 +37,7 @@
       "oneof": null,
       "required": false,
       "repeated": false,
+      "optional": true,
       "options": {
         "mylist2": "'[more, values], [here]'"
       }

--- a/test/fixtures/service.json
+++ b/test/fixtures/service.json
@@ -20,7 +20,8 @@
 			    "map": null,
 			    "oneof": null,
 			    "required": false,
-			    "repeated": false,
+				"repeated": false,
+				"optional": true,
 			    "options": {}
 			  }
 			]

--- a/test/fixtures/version.json
+++ b/test/fixtures/version.json
@@ -41,6 +41,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ]
@@ -81,6 +82,7 @@
           "oneof": null,
           "required": false,
           "repeated": false,
+          "optional": true,
           "options": {}
         }
       ]


### PR DESCRIPTION
Whilst all fields in proto3 are optional, in the sense that they can be omitted from the message serialization, the `optional` keyword still carries a meaning. For fields that are not explicitly marked `optional` then when the field is missing from a message this is considered equivalent to the field being present with default value. APIs need not distinguish these two cases. When fields are explicitly marked `optional` (or if they are in a `oneof`) then the field missing case is a separate case from present-with-default-value case.

It would therefore be useful to expose whether a field is explicitly marked as `optional` in the parsed data structure.

This PR adds a property `optional` in the field structure that, if present and true, indicates that the field was marked explicitly as optional, or inside a `oneof`. 